### PR TITLE
Quick menu button color change

### DIFF
--- a/BytesOfLove/game/screens.rpy
+++ b/BytesOfLove/game/screens.rpy
@@ -246,8 +246,8 @@ screen quick_menu():
         hbox:
             style_prefix "quick"
 
-            xalign 0.5
-            yalign 1.0
+            xalign 1.0
+            yalign 0.5
 
             textbutton _("Back") action Rollback()
             textbutton _("History") action ShowMenu('history')


### PR DESCRIPTION
Change for the color of the quick menu buttons to allow for better visibility to the user when certain colors are presented in the background.