### PR TITLE
Fixed quick control buttons on bottom screen

### DIFF
--- a/BytesOfLove/game/gui.rpy
+++ b/BytesOfLove/game/gui.rpy
@@ -32,8 +32,6 @@ define gui.idle_color = '#888888'
 
 ## The small color is used for small text, which needs to be brighter/darker to
 ## achieve the same effect.
-## define gui.idle_small_color = '#aaaaaa'
-## This seems to control the color of the buttons at the bottom of the screen omegalul
 define gui.idle_small_color = '#ffffff'
 
 ## The color that is used for buttons and bars that are hovered.
@@ -158,8 +156,6 @@ define gui.button_width = None
 define gui.button_height = None
 
 ## The borders on each side of the button, in left, top, right, bottom order.
-## define gui.button_borders = Borders(6, 6, 6, 6)
-## This is another change that I did omegalul
 define gui.button_borders = Borders(6,6,6,6)
 
 ## If True, the background image will be tiled. If False, the background image
@@ -197,14 +193,7 @@ define gui.confirm_button_text_xalign = 0.5
 
 define gui.page_button_borders = Borders(15, 6, 15, 6)
 
-#this might be a place to look to edit the quick buttons at the bottom maybe omegalul
-
-## define gui.quick_button_borders = Borders(15, 6, 15, 0)
-## This is definitely the place for the buttons at the bottom of the page omegalul
-
 define gui.quick_button_borders = Borders(15 , 6, 15, 20)
-## I might edit this as well omegalul
-## define gui.quick_button_text_size = 21
 define gui.quick_button_text_size = 15
 define gui.quick_button_text_idle_color = gui.idle_small_color
 define gui.quick_button_text_selected_color = gui.accent_color

--- a/BytesOfLove/game/gui.rpy
+++ b/BytesOfLove/game/gui.rpy
@@ -32,7 +32,9 @@ define gui.idle_color = '#888888'
 
 ## The small color is used for small text, which needs to be brighter/darker to
 ## achieve the same effect.
-define gui.idle_small_color = '#aaaaaa'
+## define gui.idle_small_color = '#aaaaaa'
+## This seems to control the color of the buttons at the bottom of the screen omegalul
+define gui.idle_small_color = '#ffffff'
 
 ## The color that is used for buttons and bars that are hovered.
 define gui.hover_color = '#66c1e0'
@@ -156,7 +158,9 @@ define gui.button_width = None
 define gui.button_height = None
 
 ## The borders on each side of the button, in left, top, right, bottom order.
-define gui.button_borders = Borders(6, 6, 6, 6)
+## define gui.button_borders = Borders(6, 6, 6, 6)
+## This is another change that I did omegalul
+define gui.button_borders = Borders(6,6,6,6)
 
 ## If True, the background image will be tiled. If False, the background image
 ## will be linearly scaled.
@@ -193,8 +197,15 @@ define gui.confirm_button_text_xalign = 0.5
 
 define gui.page_button_borders = Borders(15, 6, 15, 6)
 
-define gui.quick_button_borders = Borders(15, 6, 15, 0)
-define gui.quick_button_text_size = 21
+#this might be a place to look to edit the quick buttons at the bottom maybe omegalul
+
+## define gui.quick_button_borders = Borders(15, 6, 15, 0)
+## This is definitely the place for the buttons at the bottom of the page omegalul
+
+define gui.quick_button_borders = Borders(15 , 6, 15, 20)
+## I might edit this as well omegalul
+## define gui.quick_button_text_size = 21
+define gui.quick_button_text_size = 15
 define gui.quick_button_text_idle_color = gui.idle_small_color
 define gui.quick_button_text_selected_color = gui.accent_color
 


### PR DESCRIPTION
I fixed the control buttons on the bottom screen. I made the buttons bright white to make it easier for a player to be able to see them, I also repositioned the buttons to be stationed firmly within the text box, and not outside of the text box. I also took the liberty of shrinking the size of the buttons to make them more aesthetically pleasing to look at, and give them more equal spacing.

Before: 
![BytesOfLoveOriginal](https://github.com/ufosc/VisualNovel/assets/88461715/b33970a8-7f21-484a-ba7d-42e9fc193a36)

After:

![BytesOfLoveChanges](https://github.com/ufosc/VisualNovel/assets/88461715/3608f4e4-a575-4b1a-95dc-ccde66656902)
