### PR TITLE
ci: create build action for push/prs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,50 @@
+name: Build Bytes of Love
+on:
+  - push
+  - pull_request
+
+jobs:
+  renpy-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Extract short commit hash
+        shell: bash
+        run: echo "git_hash=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_OUTPUT
+        id: ref
+
+      - name: Setup Ren'Py and Build
+        run: |
+          wget https://www.renpy.org/dl/8.3.2/renpy-8.3.2-sdk.tar.bz2
+          tar -xf renpy-8.3.2-sdk.tar.bz2
+          ( cd renpy-8.3.2-sdk && ./renpy.sh launcher distribute ../BytesOfLove --destination ../dist --package win --package mac --package linux )
+
+      - name: Process Files
+        run: python .github/workflows/process.py ${{ steps.ref.outputs.git_hash }}
+
+      - name: Upload Linux Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: BytesOfLove-linux-${{ steps.ref.outputs.git_hash }}
+          path: dist/BytesOfLove-linux-${{ steps.ref.outputs.git_hash }}.tar.bz2
+          compression-level: 0
+
+      - name: Upload Mac Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: BytesOfLove-mac-${{ steps.ref.outputs.git_hash }}
+          path: dist/BytesOfLove-mac-${{ steps.ref.outputs.git_hash }}.zip
+          compression-level: 0
+
+      - name: Upload Windows Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: BytesOfLove-win-${{ steps.ref.outputs.git_hash }}
+          path: dist/BytesOfLove-win-${{ steps.ref.outputs.git_hash }}

--- a/.github/workflows/process.py
+++ b/.github/workflows/process.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+from zipfile import ZipFile
+
+commit_hash = sys.argv[1]
+
+files = Path("dist").glob('*')
+
+for a_file in files:
+    if not a_file.is_file():
+        continue
+
+    if a_file.suffix == ".zip":
+        platform = a_file.stem.split("-")[-1].removesuffix(".zip")
+
+        if platform == "win":
+            print("Extracting", a_file)
+            with ZipFile(a_file, 'r') as zip_ref:
+                zip_ref.extractall(f"dist/BytesOfLove-{platform}-{commit_hash}")
+            print("Extracted", a_file)
+        else:
+            # due to https://github.com/actions/upload-artifact?tab=readme-ov-file#permission-loss,
+            # we don't want to extract the file in the fears of losing certain permissions
+            # windows doesn't care though
+            print("Renaming", a_file)
+            a_file.rename(f"dist/BytesOfLove-{platform}-{commit_hash}.zip")
+
+    elif a_file.suffix == ".bz2":
+        # see above
+        print("Renaming", a_file)
+        a_file.rename("dist/BytesOfLove-linux-" + commit_hash + ".tar.bz2")

--- a/BytesOfLove/game/scripts/before_orientation/before_orientation.rpy
+++ b/BytesOfLove/game/scripts/before_orientation/before_orientation.rpy
@@ -27,7 +27,7 @@ label w0_d1:
     label w0_d1_End:
         scene w0_d1_hotel with longer_fade
         mc "Man that hit the spot."
-        mc "What am I going to do with the rest of my night?"
+        mc "Now what should I do with the rest of my night?"
         mc "I know I’ll play some Valorant. I’ve been grinding so I can go from silver to gold."
         #Add clock below when it is made - Lazzy
         scene w0_d1_hotel with shorter_fade


### PR DESCRIPTION
This PR creates a build action for any pushes or PRs done to the repository, packaging up the game so that testing the final result is as simple as downloading the right file for your platform (and doing some extracting steps).

## For the End User
- For commits and PRs, users will be able to go to the "Actions" tab of this repo and see builds for each commit. You can get a little peak of that [on the forked repo](https://github.com/PythiaUF/VisualNovel/actions) - essentially, they can click on the title, can download the artifact for their system, and they are all set.
- For commits, a green check will appear next to commits on the main and [commits page](https://github.com/PythiaUF/VisualNovel/commits/auto-build/), which if they press on, click "Details", then click on "Summary", they'll also be able to download the artifacts from there.
- For PRs, a similar process can be done: click on the green checkmark that will appear next to them on the Pull Requests page and go through the same process. I don't have an example for this for this project, but I can [point you to the Sodium for MC repo](https://github.com/CaffeineMC/sodium-fabric/pulls) as an example.

## Technical Details
- Most of this is done through the [Ren'Py CLI](https://www.renpy.org/doc/html/cli.html), which allows us to make distributions for platforms using it. We do have to set up the CLI using commands, as can be seen, but it's relatively easy to use after that.
  - The version is currently hardcoded into the Action file. This is probably not an issue for now, but may be in the future.
- I likely could have made a small shell script to do what `process.py` does - it goes through the files generated from the CLI and renames/extracts them to make it easier to upload them to GitHub. That being said, I wanted the script to be dynamic and handle any number of inputs, and that didn't sound pleasant with Bash. GitHub doesn't care how long Actions run for public repos anyways, we should be good :P.
- For Mac and Linux, the artifacts are a little... weird. They are zip files that contain *another* archive within them, which is likely to be annoying at best. However, when uploading files to be used as artifacts, [GitHub strips permission data from files](https://github.com/actions/upload-artifact?tab=readme-ov-file#permission-loss), which causes the game not to run. Doing this weird solution allows permissions to be kept during the upload.
  - Windows does not have proper file permissions (not any that would affect this), and so the archive can be (and is) a lot more normal. Yay for Windows?

## Note
- I haven't tested the resulting files on a Mac, though I *did* test the Windows and Linux files.