### PR TITLE
Fixing Issues in w0_d3 CppCopy

### DIFF
--- a/BytesOfLove/game/scripts/orientation/w0_d3.rpy
+++ b/BytesOfLove/game/scripts/orientation/w0_d3.rpy
@@ -11,11 +11,14 @@ label w0_d3:
     mc"Oh wow! Everything looks so good!"
     "{i}While holding your food you notice that there is only one seat available, and it’s next to a boy who looks about your age.{/i}"
     mc"Well, I guess I’m eating with him."
+    jump w0_d3_MeetingRust
 
-    # jump w0_d3_MeetingRust
-    
+label w0_d3_AfterMeetingRust:
+    # Fade to orientation...
+    # ...It seems like she always has it figured out
+    jump w0_d3_CppCopy
 
-
+label w0_d3_Registration:
     scene office with longer_fade
     show advisor at right with dissolve
     a"\"Hey there, sugar!\""

--- a/BytesOfLove/game/scripts/orientation/w0_d3_choices/w0_d3_CppCopy.rpy
+++ b/BytesOfLove/game/scripts/orientation/w0_d3_choices/w0_d3_CppCopy.rpy
@@ -1,9 +1,8 @@
 label w0_d3_CppCopy:
     mc "\"Definitely no reason to stress myself out, C++ will have me covered.\""
     mc "\"You know, I’m actually getting kind of sleepy…\""
-    # insert transition to empty classroom
-
-    p "\"HEY, [mc]!\""
+    scene empty_lecture_hall with longer_fade
+    p "\"HEY, [mc]!\"" with hpunch
     p "\"Are you coming? Everyone is going to the administrative building to pick their classes.\""
     mc "{i}Sleepy and confused.{/i} \"Woah, what happened?\""
     mc "\"I swear I was listening to the breakout leader talk about Calc 1, and that’s the last thing I remember…\""
@@ -30,7 +29,7 @@ label w0_d3_CppCopy:
         p "\"Also, I can catch you up on what you missed while you were asleep.\""
 
         "Give a friendly compliment":
-            # affects python positively
+            $ r_rep = reputation(r_rep, 1)
             mc "\"Also, I really like your hair today, it looks good.\""
             p "\"Thank you!\""
             p "\"I like your outfit today, you have good style.\""
@@ -39,8 +38,8 @@ label w0_d3_CppCopy:
             mc "\"We should probably get going now, so that we don’t completely miss registration.\""
             p "\"Okay, good idea.\""
 
-        "Give a bold compliment":
-            #affects python negatively 
+        "Give a rude compliment":
+            $ r_rep = reputation(r_rep, -1)
             mc "\"Anywho…\""
             mc "\"I bet you get a lot of guys looking at you dressed like that.\""
             mc "\"I doubt there are many women on campus hotter than you.\""
@@ -56,7 +55,7 @@ label w0_d3_CppCopy:
             mc "\"We should probably get going now, so that we don’t completely miss registration.\""
             p "\"Okay, good idea.\""
 
-
+    # jump to next scene
 
 
 

--- a/BytesOfLove/game/scripts/orientation/w0_d3_choices/w0_d3_MeetingRust.rpy
+++ b/BytesOfLove/game/scripts/orientation/w0_d3_choices/w0_d3_MeetingRust.rpy
@@ -166,7 +166,7 @@ label w0_d3_MeetingRust:
                 "{i}Rust leaves.{/i}"
             
             "\"I made three friends.\"":
-                $ r_rep = reputation(r_rep, -1)
+                $ r_rep = reputation(r_rep, 1)
                 mc "\"When I eventually made it to my breakout room, there was only one place to sit.\""
                 mc "\"Luckily, that table had 3 girls at it who were really nice.\""
                 r "\"Oh, cool!\""
@@ -183,3 +183,5 @@ label w0_d3_MeetingRust:
                 r "\"I’ll see you later!\""
                 mc "\"Bye!\""
                 "{i}Rust leaves.{/i}"
+    
+    jump w0_d3_AfterMeetingRust


### PR DESCRIPTION
Fixes issue 149. Moved w0_d3_CppCopy into w0_d3_choices. Deleted old folder. Change character love levels in w0_d3_CppCopy (and fixed one in w0_d3_MeetingRust). Changed title of second option. Linked with w0_d3. Also added hpunch when woken up by Python.